### PR TITLE
#118748897 Fix Twiiter Auth Bug

### DIFF
--- a/app/Http/Controllers/UserDashboardController.php
+++ b/app/Http/Controllers/UserDashboardController.php
@@ -5,7 +5,6 @@ namespace Pyjac\Techphin\Http\Controllers;
 use Cloudder;
 use Pyjac\Techphin\Category;
 use Pyjac\Techphin\Http\Requests\UserProfileRequest;
-use Pyjac\Techphin\Http\Requests\VideoUploadRequest;
 use Pyjac\Techphin\Tag;
 use Pyjac\Techphin\Video;
 

--- a/app/SocialAccountService.php
+++ b/app/SocialAccountService.php
@@ -51,6 +51,10 @@ class SocialAccountService
         if (strpos(strtolower($providerName), 'github') !== false) {
             $avatar = $providerUser->avatar;
         }
+        // If the email returned is null, we concatenate the user provider Id,
+        // `@` and provider name for email field.
+        $email = $providerUser->getEmail()
+                                ? $providerUser->getEmail() : $providerUser->getId().'@'.$providerName;
 
         return User::create([
             'email'     => $providerUser->getEmail(),

--- a/tests/VideoControllerTest.php
+++ b/tests/VideoControllerTest.php
@@ -1,8 +1,11 @@
 <?php
 
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class VideoControllerTest extends TestCase
 {
+    use DatabaseTransactions;
+
     public function testVideoUploadWhenAllFieldsArePassedCorrectly()
     {
         $user = factory(Pyjac\Techphin\User::class)->create();


### PR DESCRIPTION
- If the email returned is null, we concatenate the user provider Id, `@` and provider name for email field.
